### PR TITLE
fix GDI leaks that case app crashing

### DIFF
--- a/Taskbar11/Taskbar11.cpp
+++ b/Taskbar11/Taskbar11.cpp
@@ -458,12 +458,12 @@ void SetWindowRegionAnimated(HWND hWND, HRGN region) {
 			if (square == 0) {
 				HRGN framereg = CreateRoundRectRgn(left, top, right, bottom, corner_Radius, corner_Radius);
 				SetWindowRgn(hWND, framereg, TRUE);
-				framereg = NULL;
+				DeleteObject(framereg);
 			}
 			else {
 				HRGN framereg = CreateRectRgn(left, top, right, bottom);
 				SetWindowRgn(hWND, framereg, TRUE);
-				framereg = NULL;
+				DeleteObject(framereg);
 			}
 
 			currentTime = NULL;
@@ -1166,7 +1166,7 @@ void SetTaskbar() {
 							}
 						}
 
-						region_Both = NULL;
+						DeleteObject(region_Both);
 					}
 
 				//	std::wcout << "Done with " << "Shell_TrayWnd" << " @ " << Shell_TrayWnd << std::endl;
@@ -1186,8 +1186,8 @@ void SetTaskbar() {
 					right = NULL;
 					bottom = NULL;
 					top = NULL;
-					region_ShellTrayWnd = NULL;
-					region_TrayNotifyWnd = NULL;
+					DeleteObject(region_ShellTrayWnd);
+					DeleteObject(region_TrayNotifyWnd);
 					DesktopWindowContentBridge = NULL;
 					ToolbarWindow32 = NULL;
 					SysPager = NULL;
@@ -1377,7 +1377,7 @@ void SetTaskbar() {
 						else {
 						//	std::wcout << "Shell_SecondaryTrayWnd" << " @ " << Shell_SecondaryTrayWnd << " does not need new HRGN!" << std::endl;
 						}
-						region_Shell_SecondaryTrayWnd = NULL;
+						DeleteObject(region_Shell_SecondaryTrayWnd);
 					}
 
 				//	std::wcout << "Done with " << "Shell_SecondaryTrayWnd" << " @ " << Shell_SecondaryTrayWnd << std::endl;
@@ -1387,7 +1387,7 @@ void SetTaskbar() {
 					right = NULL;
 					bottom = NULL;
 					top = NULL;
-					currenttbreg = NULL;
+					DeleteObject(currenttbreg);
 					Shell_SecondaryTrayWnd = NULL;
 					//Start = NULL;
 					WorkerW = NULL;


### PR DESCRIPTION
I work for the Microsoft Graphics team, and I notice that your app is leaking GDI objects. These leaks make your app crash suddenly on the user.

When you use GDI objects such as
* [CreateRoundRectRgn](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createroundrectrgn)
* [CreateRectRgn](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createrectrgn)
you need  to release object from the kernel space using [DeleteObject](https://learn.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-deleteobject) do not set the object to NULL it is a leak. as MSDN said
"When you no longer need the HRGN object, call the [DeleteObject](https://learn.microsoft.com/en-us/windows/desktop/api/wingdi/nf-wingdi-deleteobject)"
 
Once your all use all [quotes](https://learn.microsoft.com/en-us/windows/win32/sysinfo/gdi-objects) for GDI object per process because of the leak the app will crash. Please fix/verify PR as soon as possible.
I address leaks as much as I can I am not sure I address all leaks please find other leaks if there are any and fix them, your app is a good and nice App.
Thanks
Hussein